### PR TITLE
fix: update save changes button routing

### DIFF
--- a/Front-end/src/app/add-habit/page.tsx
+++ b/Front-end/src/app/add-habit/page.tsx
@@ -235,7 +235,7 @@ export default function AddHabits() {
       }
     }
 
-    router.push("/");
+    router.push("/habits");
   };
 
   if (loading) {


### PR DESCRIPTION
Updated the save changes button routing to redirect users to the /habits page instead of the root path. This change improves user flow by directing users to a more relevant destination after saving their changes. The update ensures users land on the habits page where they can immediately see the results of their saved modifications.