### PR TITLE
fix: correct link on sign up page

### DIFF
--- a/Front-end/src/app/sign-up/page.tsx
+++ b/Front-end/src/app/sign-up/page.tsx
@@ -89,7 +89,7 @@ export default function SignUpPage() {
               href="/login"
               className="text-green-400 hover:text-green-300 underline transition-colors duration-200"
             >
-              Sign up
+              Log in
             </Link>
           </p>
         </div>


### PR DESCRIPTION
Fix link on sign up page to say 'already have an account log in' instead of sign up