### PR TITLE
refactor: create EditableHabitInput component for habit management

### DIFF
--- a/Front-end/src/app/add-habit/page.tsx
+++ b/Front-end/src/app/add-habit/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { HiOutlinePencil } from "react-icons/hi2";
-import { IoIosCloseCircleOutline } from "react-icons/io";
-import { IoIosCheckmarkCircle } from "react-icons/io";
 import { createClient } from "@/utils/supabase/client";
-import { H1, TextBox } from "@/components";
+import { H1, EditableHabitInput } from "@/components";
 
 
 interface Habit {
@@ -260,66 +257,19 @@ export default function AddHabits() {
         </p>
 
         {habits.map((habit, idx) => (
-          <div key={idx} className="flex items-center gap-2">
-            <div className="flex-1" style={{ marginBottom: 0 }}>
-              <TextBox
-                label=""
-                type="text"
-                name={`habit_${idx}`}
-                id={`habit_${idx}`}
-                value={habit}
-                maxLength={50}
-                placeholder={`Habit ${idx + 1}`}
-                onChange={(e) => handleChange(idx, e.target.value)}
-                disabled={habitDisabled[idx]}
-                className={
-                  habitDisabled[idx]
-                    ? "bg-gray-300 disabled focus:outline-none"
-                    : "hover:ring-2 hover:ring-green-500 focus:outline-none transition-colors duration-200"
-                }
-              />
-            </div>
-            {/* return either edit icon or save icon based on the state of habitDisabled */}
-            {habit != "" && habitDisabled[idx] ? (
-              <div className="flex items-center gap-1">
-                <button
-                  type="button"
-                  className="p-1 text-gray-500 hover:text-green-600"
-                  onClick={() => handleEdit(idx, false)}
-                  aria-label="Edit habit"
-                >
-                  <HiOutlinePencil className="h-5 w-5" />
-                </button>
-                <button
-                  type="button"
-                  className="p-1 text-gray-500 hover:text-red-600"
-                  onClick={() => handleDelete(idx)}
-                  aria-label="Delete habit"
-                >
-                  <IoIosCloseCircleOutline className="h-6 w-6" />
-                </button>
-              </div>
-            ) : (
-              <div>
-                <button
-                  type="button"
-                  className="p-1"
-                  onClick={() => handleEdit(idx, true)}
-                  aria-label="Save habit"
-                >
-                  <IoIosCheckmarkCircle className="h-6 w-6 text-green-500 hover:text-green-800" />
-                </button>
-                <button
-                  type="button"
-                  className="p-1 text-gray-500 hover:text-red-600"
-                  onClick={() => handleDelete(idx)}
-                  aria-label="Delete habit"
-                >
-                  <IoIosCloseCircleOutline className="h-6 w-6" />
-                </button>
-              </div>
-            )}
-          </div>
+          <EditableHabitInput
+            key={idx}
+            name={`habit_${idx}`}
+            id={`habit_${idx}`}
+            value={habit}
+            maxLength={50}
+            placeholder={`Habit ${idx + 1}`}
+            onChange={(value) => handleChange(idx, value)}
+            onEdit={() => handleEdit(idx, false)}
+            onSave={() => handleEdit(idx, true)}
+            onDelete={() => handleDelete(idx)}
+            disabled={habitDisabled[idx]}
+          />
         ))}
 
         <div className="flex justify-end mt-6">

--- a/Front-end/src/components/EditableHabitInput.tsx
+++ b/Front-end/src/components/EditableHabitInput.tsx
@@ -1,0 +1,95 @@
+"use client";
+import { HiOutlinePencil } from "react-icons/hi2";
+import { IoIosCloseCircleOutline, IoIosCheckmarkCircle } from "react-icons/io";
+import TextBox from "./TextBox";
+
+interface EditableHabitInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  onDelete: () => void;
+  onEdit: () => void;
+  disabled: boolean;
+  placeholder?: string;
+  maxLength?: number;
+  name: string;
+  id: string;
+}
+
+export default function EditableHabitInput({
+  value,
+  onChange,
+  onSave,
+  onDelete,
+  onEdit,
+  disabled,
+  placeholder,
+  maxLength = 50,
+  name,
+  id
+}: EditableHabitInputProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1" style={{ marginBottom: 0 }}>
+        <TextBox
+          label=""
+          type="text"
+          name={name}
+          id={id}
+          value={value}
+          maxLength={maxLength}
+          placeholder={placeholder}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          className={
+            disabled
+              ? "bg-gray-300 disabled focus:outline-none"
+              : "hover:ring-2 hover:ring-green-500 focus:outline-none transition-colors duration-200"
+          }
+        />
+      </div>
+
+      {/* Show edit/delete buttons when disabled (viewing mode) */}
+      {value !== "" && disabled ? (
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="p-1 text-gray-500 hover:text-green-600"
+            onClick={onEdit}
+            aria-label="Edit habit"
+          >
+            <HiOutlinePencil className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            className="p-1 text-gray-500 hover:text-red-600"
+            onClick={onDelete}
+            aria-label="Delete habit"
+          >
+            <IoIosCloseCircleOutline className="h-6 w-6" />
+          </button>
+        </div>
+      ) : (
+        /* Show save/delete buttons when enabled (editing mode) */
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="p-1"
+            onClick={onSave}
+            aria-label="Save habit"
+          >
+            <IoIosCheckmarkCircle className="h-6 w-6 text-green-500 hover:text-green-800" />
+          </button>
+          <button
+            type="button"
+            className="p-1 text-gray-500 hover:text-red-600"
+            onClick={onDelete}
+            aria-label="Delete habit"
+          >
+            <IoIosCloseCircleOutline className="h-6 w-6" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Front-end/src/components/index.tsx
+++ b/Front-end/src/components/index.tsx
@@ -2,6 +2,7 @@
 export { default as AppHeader } from './AppHeader';
 export { default as Button } from './Button';
 export { default as Container } from './Container';
+export { default as EditableHabitInput } from './EditableHabitInput';
 export { default as Footer } from './Footer';
 export { default as H1 } from './H1';
 export { default as HabitCell } from './HabitCell';


### PR DESCRIPTION
- Create reusable EditableHabitInput component that combines TextBox with edit/save/delete buttons
- Component handles viewing mode (edit/delete buttons) and editing mode (save/delete buttons)
- Encapsulates all habit editing UI logic and button conditional rendering
- Update add-habit page to use EditableHabitInput component
- Remove icon imports from add-habit page (now handled in component)
- Reduce code duplication by ~60 lines