### PR TITLE
refactor: migrate all page buttons to Button component (#439)

### DIFF
--- a/Front-end/src/app/add-habit/page.tsx
+++ b/Front-end/src/app/add-habit/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/utils/supabase/client";
-import { H1, EditableHabitInput } from "@/components";
+import { H1, EditableHabitInput, Button } from "@/components";
 
 
 interface Habit {
@@ -275,8 +275,7 @@ export default function AddHabits() {
         <div className="flex justify-end mt-6">
           {/* show add button only if habits length is less than 5 */}
           {habits.length < 5 && (
-            <button
-              type="button"
+            <Button
               onClick={() => {
                 if (habits.length < 5) {
                   setHabits([...habits, ""]);
@@ -286,19 +285,18 @@ export default function AddHabits() {
                 }
               }}
               disabled={habits.length == 5}
-              className="bg-green-600 hover:bg-green-800 text-white font-bold py-2 px-4 rounded-full transition-colors duration-200"
+              type="primary"
+              roundedFull
+              className="font-bold"
             >
               +
-            </button>
+            </Button>
           )}
         </div>
         <div className="flex justify-center mt-6">
-          <button
-            className="bg-green-600 text-white rounded px-4 py-2 hover:bg-green-800 transition-colors duration-200"
-            type="submit"
-          >
+          <Button htmlType="submit" type="primary">
             Save Changes
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/Front-end/src/app/error/page.tsx
+++ b/Front-end/src/app/error/page.tsx
@@ -3,7 +3,7 @@
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useEffect, useState, Suspense } from 'react'
 import Link from 'next/link'
-import { H1 } from "@/components";
+import { H1, Button } from "@/components";
 
 
 function ErrorPageContent() {
@@ -11,8 +11,6 @@ function ErrorPageContent() {
   const router = useRouter()
   const [returnPath, setReturnPath] = useState('/login')
   const [returnLabel, setReturnLabel] = useState('Return to Login')
-  const secondaryButtonClass = "border-2 border-green-600 text-green-600 rounded px-4 py-2 hover:bg-green-600 hover:text-white transition-colors duration-200"
-
 
   useEffect(() => {
     // Check if there's a 'from' parameter in the URL
@@ -75,19 +73,22 @@ function ErrorPageContent() {
 
         {/* Action Buttons */}
         <div className="mt-12 space-y-4">
-          <button
+          <Button
             onClick={handleRetry}
-            className="w-full bg-green-600 text-white rounded px-4 py-2 hover:bg-green-700 transition-colors duration-200"
+            type="primary"
+            fullWidth
           >
             {returnLabel}
-          </button>
-          
-          <button
+          </Button>
+
+          <Button
             onClick={handleHome}
-            className={secondaryButtonClass + " w-full"}
+            type="primary"
+            variant="outline"
+            fullWidth
           >
             Go to Home
-          </button>
+          </Button>
         </div>
 
         {/* Additional Help */}

--- a/Front-end/src/app/get-started/page.tsx
+++ b/Front-end/src/app/get-started/page.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { HiOutlinePencil } from "react-icons/hi2";
 import { IoIosCloseCircleOutline, IoIosCheckmarkCircle } from "react-icons/io";
 import { useRouter } from "next/navigation";
-import { H1, Container }  from "@/components";
+import { H1, Container, Button }  from "@/components";
 
 export default function GettingStarted() {
   const [currentStep, setCurrentStep] = useState(0);
@@ -166,9 +166,6 @@ export default function GettingStarted() {
     }
   };
 
-  const activeButtonClass = "bg-green-600 text-white rounded px-3 sm:px-4 py-2 hover:bg-green-700 transition-colors duration-200 text-sm sm:text-base"
-  const secondaryButtonClass = "border-2 border-green-600 text-green-600 rounded px-3 sm:px-4 py-2 hover:bg-green-600 hover:text-white transition-colors duration-200 text-sm sm:text-base"
-
   if (!mounted) {
     return (
       <div className="min-h-screen bg-gray-900 flex justify-center items-center">
@@ -212,13 +209,15 @@ export default function GettingStarted() {
 
         {/* Navigation */}
         <div className="flex justify-between items-center gap-2">
-          <button
+          <Button
             onClick={prevStep}
             disabled={currentStep === 0}
-            className={currentStep === 0 ? secondaryButtonClass + " opacity-50 cursor-not-allowed" : secondaryButtonClass}
+            type="primary"
+            variant="outline"
+            className="text-sm sm:text-base px-3 sm:px-4"
           >
             Previous
-          </button>
+          </Button>
 
           <div className="flex gap-1.5 sm:gap-2">
             {steps.map((_, index) => (
@@ -237,20 +236,22 @@ export default function GettingStarted() {
           </div>
 
           {currentStep === steps.length - 1 ? (
-            <button
+            <Button
               onClick={() => router.push("/home")}
-              className={activeButtonClass + " px-4 sm:px-6 font-semibold"}
+              type="primary"
+              className="px-4 sm:px-6 font-semibold text-sm sm:text-base"
             >
               <span className="hidden sm:inline">Get Started!</span>
               <span className="sm:hidden">Start!</span>
-            </button>
+            </Button>
           ) : (
-            <button
+            <Button
               onClick={nextStep}
-              className={activeButtonClass}
+              type="primary"
+              className="text-sm sm:text-base px-3 sm:px-4"
             >
               Next
-            </button>
+            </Button>
           )}
         </div>
 

--- a/Front-end/src/app/report-bug/page.tsx
+++ b/Front-end/src/app/report-bug/page.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { HiOutlineCamera, HiOutlineInformationCircle } from "react-icons/hi";
 import { FaBug } from "react-icons/fa";
 import { createClient } from "@/utils/supabase/client";
-import { H1, TextBox, Container } from "@/components";
+import { H1, TextBox, Container, Button } from "@/components";
 
 export default function BugReport() {
   const supabase = createClient();
@@ -132,7 +132,7 @@ export default function BugReport() {
                 Your bug report has been submitted successfully. I'll investigate and get back to you soon.
               </p>
               <div className="space-y-4">
-                <button
+                <Button
                   onClick={() => {
                     setSubmitSuccess(false);
                     setFormData({
@@ -144,16 +144,18 @@ export default function BugReport() {
                       severity: "Medium",
                     });
                   }}
-                  className="bg-green-600 text-white rounded px-6 py-2 hover:bg-green-700 transition-colors duration-200 mr-4"
+                  type="primary"
+                  className="mr-4"
                 >
                   Submit Another Report
-                </button>
-                <button
+                </Button>
+                <Button
                   onClick={() => window.history.back()}
-                  className="border-2 border-green-600 text-green-600 rounded px-6 py-2 hover:bg-green-600 hover:text-white transition-colors duration-200"
+                  type="primary"
+                  variant="outline"
                 >
                   ← Back to App
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -309,13 +311,14 @@ export default function BugReport() {
 
                 {/* Submit Button */}
                 <div className="text-center pt-4">
-                  <button
-                    type="submit"
+                  <Button
+                    htmlType="submit"
+                    type="danger"
                     disabled={isSubmitting || !formData.title || !formData.description}
-                    className="bg-red-600 text-white rounded px-8 py-3 hover:bg-red-700 transition-colors duration-200 disabled:bg-gray-600 disabled:cursor-not-allowed text-lg font-semibold"
+                    className="px-8 py-3 text-lg font-semibold"
                   >
                     {isSubmitting ? "Submitting..." : "Submit Bug Report"}
-                  </button>
+                  </Button>
                 </div>
               </div>
             </Container>
@@ -341,12 +344,13 @@ export default function BugReport() {
 
           {/* Back to App */}
           <div className="text-center mt-6">
-            <button
+            <Button
               onClick={() => window.history.back()}
-              className="border-2 border-red-600 text-red-600 rounded px-6 py-2 hover:bg-red-600 hover:text-white transition-colors duration-200"
+              type="danger"
+              variant="outline"
             >
               ← Back to App
-            </button>
+            </Button>
           </div>
 
         </div>

--- a/Front-end/src/app/reset-password/page.tsx
+++ b/Front-end/src/app/reset-password/page.tsx
@@ -4,7 +4,7 @@ import { resetPassword } from "./actions";
 import "../../utils/styles/global.css";
 import Link from "next/link";
 import { useState, FormEvent, use } from "react";
-import { H1 } from "@/components";
+import { H1, Button } from "@/components";
 
 
 export default function ResetPasswordPage({
@@ -26,11 +26,6 @@ export default function ResetPasswordPage({
   // Derived state - automatically recalculates when password or confirmPassword changes
   const passwordsMatch = password === confirmPassword && confirmPassword !== '';
   const showError = confirmPassword !== '' && !passwordsMatch;
-
-  const activeButtonClass =
-    "bg-green-600 text-white rounded px-4 py-2 hover:bg-green-700 transition-colors duration-200";
-  const disabledButtonClass =
-    "bg-gray-400 text-gray-200 rounded px-4 py-2 cursor-not-allowed";
 
   const getErrorMessage = (error?: string) => {
     switch (error) {
@@ -175,14 +170,14 @@ export default function ResetPasswordPage({
 
           {/* Submit */}
           <div style={{ marginTop: "1.5rem", marginBottom: "1rem" }}>
-            <button
-              type="submit"
+            <Button
+              htmlType="submit"
+              type="primary"
               disabled={!passwordsMatch}
-              className={passwordsMatch ? activeButtonClass : disabledButtonClass}
-              style={{ width: "100%", padding: "0.5rem" }}
+              fullWidth
             >
               Reset Password
-            </button>
+            </Button>
           </div>
         </form>
         

--- a/Front-end/src/app/sign-up/page.tsx
+++ b/Front-end/src/app/sign-up/page.tsx
@@ -4,7 +4,7 @@ import { signup } from "./actions";
 import "../../utils/styles/global.css";
 import Link from "next/link";
 import { useState, FormEvent } from "react";
-import { H1, TextBox } from "@/components";
+import { H1, TextBox, Button } from "@/components";
 
 export default function SignUpPage() {
   // State for form fields
@@ -16,13 +16,6 @@ export default function SignUpPage() {
   // Derived state - automatically recalculates when password or confirmPassword changes
   const passwordsMatch = password === confirmPassword && confirmPassword !== '';
   const showError = confirmPassword !== '' && !passwordsMatch;
-
-  const activeButtonClass =
-    "bg-green-600 text-white rounded px-4 py-2 hover:bg-green-700 transition-colors duration-200";
-  const secondaryButtonClass =
-    "border-2 border-green-600 text-green-600 rounded px-4 py-2 hover:bg-green-600 hover:text-white transition-colors duration-200";
-  const disabledButtonClass =
-    "bg-gray-400 text-gray-200 rounded px-4 py-2 cursor-not-allowed";
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -93,14 +86,14 @@ export default function SignUpPage() {
 
           {/* Submit */}
           <div style={{ marginTop: "1.5rem", marginBottom: "1rem" }}>
-            <button
-              type="submit"
+            <Button
+              htmlType="submit"
+              type="primary"
               disabled={!passwordsMatch}
-              className={passwordsMatch ? activeButtonClass : disabledButtonClass}
-              style={{ width: "100%", padding: "0.5rem" }}
+              fullWidth
             >
               Create Account
-            </button>
+            </Button>
           </div>
         </form>
         

--- a/Front-end/src/app/welcome/page.tsx
+++ b/Front-end/src/app/welcome/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { H1, Container } from "@/components";
+import { H1, Container, Button } from "@/components";
 import "../../utils/styles/global.css";
 
 export default function Welcome() {
@@ -11,9 +11,6 @@ export default function Welcome() {
   useEffect(() => {
     setMounted(true);
   }, []);
-
-  const activeButtonClass = "bg-green-600 text-white rounded px-4 py-2 hover:bg-green-700 transition-colors duration-200";
-  const secondaryButtonClass = "border-2 border-green-600 text-green-600 rounded px-4 py-2 hover:bg-green-600 hover:text-white transition-colors duration-200";
 
   const handleGetStarted = () => {
     router.push("/get-started");
@@ -59,19 +56,22 @@ export default function Welcome() {
 
           {/* Action Buttons */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-            <button
+            <Button
               onClick={handleGetStarted}
-              className={secondaryButtonClass + " w-full sm:w-auto px-6 py-3 font-semibold text-sm sm:text-base"}
+              type="primary"
+              variant="outline"
+              className="w-full sm:w-auto px-6 py-3 font-semibold text-sm sm:text-base"
             >
               Learn how to track
-            </button>
+            </Button>
 
-            <button
+            <Button
               onClick={handleLogin}
-              className={activeButtonClass + " w-full sm:w-auto px-6 py-3 font-semibold text-sm sm:text-base"}
+              type="primary"
+              className="w-full sm:w-auto px-6 py-3 font-semibold text-sm sm:text-base"
             >
               Login to Start Tracking
-            </button>
+            </Button>
           </div>
 
           {/* Subtitle */}

--- a/Front-end/src/components/Button.tsx
+++ b/Front-end/src/components/Button.tsx
@@ -7,9 +7,12 @@ interface ButtonProps {
   disabled?: boolean;
   onClick?: () => void;
   className?: string;
-  type?: 'primary' | 'secondary';
-  htmlType?: 'button' | 'submit' | 'reset';  // Add this
-  loading?: boolean;  // Optional: add this if you want loading state
+  type?: 'primary' | 'secondary' | 'danger';
+  variant?: 'solid' | 'outline';
+  htmlType?: 'button' | 'submit' | 'reset';
+  loading?: boolean;
+  fullWidth?: boolean;
+  roundedFull?: boolean;
 }
 
 const Button: React.FC<ButtonProps> = ({
@@ -18,25 +21,45 @@ const Button: React.FC<ButtonProps> = ({
   disabled = false,
   onClick,
   className = '',
-  type,
-  htmlType = 'button',  // Add this with default value
-  loading = false  // Optional: add this
+  type = 'primary',
+  variant = 'solid',
+  htmlType = 'button',
+  loading = false,
+  fullWidth = false,
+  roundedFull = false
 }) => {
-  // Your original styles
-  const baseStyles = 'rounded px-4 py-2 transition-colors duration-200 text-center';
-  
+  const baseStyles = `${roundedFull ? 'rounded-full' : 'rounded'} px-4 py-2 transition-colors duration-200 text-center ${fullWidth ? 'w-full' : ''}`;
+
   let buttonClass = '';
 
-  if (disabled || loading) {  // Optional: include loading in disabled state
-    buttonClass = `${baseStyles} bg-gray-400 text-gray-200 cursor-not-allowed ${className}`
-  } else if (type == "secondary") {
-    buttonClass = `${baseStyles} bg-gray-600 hover:bg-gray-700 text-white ${className}`
+  if (disabled || loading) {
+    buttonClass = `${baseStyles} bg-gray-600 text-gray-200 cursor-not-allowed disabled:bg-gray-600 disabled:cursor-not-allowed ${className}`;
   } else {
-    buttonClass = `${baseStyles} bg-green-600 text-white hover:bg-green-700 ${className}`;
+    // Determine color scheme based on type
+    if (type === 'danger') {
+      if (variant === 'outline') {
+        buttonClass = `${baseStyles} border-2 border-red-600 text-red-600 hover:bg-red-600 hover:text-white ${className}`;
+      } else {
+        buttonClass = `${baseStyles} bg-red-600 text-white hover:bg-red-700 ${className}`;
+      }
+    } else if (type === 'secondary') {
+      if (variant === 'outline') {
+        buttonClass = `${baseStyles} border-2 border-gray-600 text-gray-600 hover:bg-gray-600 hover:text-white ${className}`;
+      } else {
+        buttonClass = `${baseStyles} bg-gray-600 hover:bg-gray-700 text-white ${className}`;
+      }
+    } else {
+      // primary
+      if (variant === 'outline') {
+        buttonClass = `${baseStyles} border-2 border-green-600 text-green-600 hover:bg-green-600 hover:text-white ${className}`;
+      } else {
+        buttonClass = `${baseStyles} bg-green-600 text-white hover:bg-green-700 ${className}`;
+      }
+    }
   }
 
   // If href is provided, render as Link
-  if (href && !disabled && !loading) {  // Optional: prevent link when loading
+  if (href && !disabled && !loading) {
     return (
       <Link href={href} className={buttonClass}>
         {children}
@@ -47,10 +70,10 @@ const Button: React.FC<ButtonProps> = ({
   // Otherwise render as button
   return (
     <button
-      type={htmlType}  // Add this
+      type={htmlType}
       className={buttonClass}
       onClick={onClick}
-      disabled={disabled || loading}  // Optional: disable when loading
+      disabled={disabled || loading}
     >
       {children}
     </button>


### PR DESCRIPTION
Enhanced Button component with danger type, outline variant, fullWidth, and roundedFull props. Migrated all standard buttons across 7 pages (add-habit, report-bug, sign-up, reset-password, get-started, welcome, error) to use the centralized Button component for consistency.