### PR TITLE
refactor: create PageHeader component and migrate 2 pages (#446)

### DIFF
--- a/Front-end/src/app/contact/page.tsx
+++ b/Front-end/src/app/contact/page.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from "react";
 import { HiOutlineMail, HiOutlineGlobeAlt } from "react-icons/hi";
 import { FaGithub, FaTwitter, FaLinkedin } from "react-icons/fa";
-import { Button, H1, Container, Loading, PageLayout }  from "@/components";
+import { Button, H1, Container, Loading, PageLayout, PageHeader }  from "@/components";
 
 export default function Contact() {
   const [mounted, setMounted] = useState(false);
@@ -30,15 +30,12 @@ export default function Contact() {
     <PageLayout maxWidth="2xl">
       <div className="flex flex-col gap-6">
         {/* Header */}
-          <div className="text-center mb-6">
-            <div className="w-20 h-20 bg-green-500 rounded-lg flex items-center justify-center mx-auto mb-4">
-              <HiOutlineMail className="text-white text-3xl" />
-            </div>
-            <H1 text="Hey you" />
-            <p className="text-gray-300 text-lg">
-              Let's get in touch
-            </p>
-          </div>
+        <PageHeader
+          icon={<HiOutlineMail className="text-white text-3xl" />}
+          iconBgColor="green"
+          title="Hey you"
+          subtitle="Let's get in touch"
+        />
 
           {/* Contact Methods */}
           <Container color="green" padding="lg">

--- a/Front-end/src/app/report-bug/page.tsx
+++ b/Front-end/src/app/report-bug/page.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { HiOutlineCamera, HiOutlineInformationCircle } from "react-icons/hi";
 import { FaBug } from "react-icons/fa";
 import { createClient } from "@/utils/supabase/client";
-import { H1, TextBox, Container, Button, Loading, PageLayout } from "@/components";
+import { H1, TextBox, Container, Button, Loading, PageLayout, PageHeader } from "@/components";
 
 export default function BugReport() {
   const supabase = createClient();
@@ -163,15 +163,12 @@ export default function BugReport() {
       <div className="flex flex-col gap-6">
           
           {/* Header */}
-          <div className="text-center mb-6">
-            <div className="w-20 h-20 bg-red-500 rounded-lg flex items-center justify-center mx-auto mb-4">
-              <FaBug className="text-white text-3xl" />
-            </div>
-            <H1 text="Report a Bug" />
-            <p className="text-gray-300 text-lg">
-              Help me improve Grains of Sand by reporting any issues you encounter.
-            </p>
-          </div>
+          <PageHeader
+            icon={<FaBug className="text-white text-3xl" />}
+            iconBgColor="red"
+            title="Report a Bug"
+            subtitle="Help me improve Grains of Sand by reporting any issues you encounter."
+          />
 
           {/* Error Message */}
           {submitError && (

--- a/Front-end/src/components/PageHeader.tsx
+++ b/Front-end/src/components/PageHeader.tsx
@@ -1,0 +1,40 @@
+import { ReactNode } from "react";
+import { H1 } from "@/components";
+
+interface PageHeaderProps {
+  icon: ReactNode;
+  iconBgColor?: "red" | "green" | "blue" | "yellow" | "purple";
+  title: string;
+  subtitle?: string;
+  className?: string;
+}
+
+const iconBgColorMap = {
+  red: "bg-red-500",
+  green: "bg-green-500",
+  blue: "bg-blue-500",
+  yellow: "bg-yellow-500",
+  purple: "bg-purple-500"
+};
+
+export default function PageHeader({
+  icon,
+  iconBgColor = "green",
+  title,
+  subtitle,
+  className = ""
+}: PageHeaderProps) {
+  return (
+    <div className={`text-center mb-6 ${className}`}>
+      <div className={`w-20 h-20 ${iconBgColorMap[iconBgColor]} rounded-lg flex items-center justify-center mx-auto mb-4`}>
+        {icon}
+      </div>
+      <H1 text={title} />
+      {subtitle && (
+        <p className="text-gray-300 text-lg">
+          {subtitle}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/Front-end/src/components/index.tsx
+++ b/Front-end/src/components/index.tsx
@@ -8,6 +8,7 @@ export { default as Footer } from './Footer';
 export { default as H1 } from './H1';
 export { default as HabitCell } from './HabitCell';
 export { default as Loading } from './Loading';
+export { default as PageHeader } from './PageHeader';
 export { default as PageLayout } from './PageLayout';
 export { default as PopupBanner } from './PopupBanner';
 export { default as StatCard } from './StatCard';


### PR DESCRIPTION
## Summary
Created a centralized PageHeader component to eliminate duplicate page header code. This component provides consistent styling for page headers with an icon, title, and optional subtitle.

## Changes
- Created `PageHeader.tsx` component with configurable props:
  - icon: ReactNode for any React icon component
  - iconBgColor: red, green, blue, yellow, or purple background colors
  - title: page title (rendered with H1 component)
  - subtitle: optional description text
  - className: additional custom styling support

- Migrated 2 pages to use PageHeader:
  - report-bug/page.tsx (red background with bug icon)
  - contact/page.tsx (green background with mail icon)

- Updated components/index.tsx to export PageHeader

## Impact
- Eliminated ~15 lines of duplicate code per page (~30 lines total)
- Improved consistency across page headers
- Simplified future page creation with standardized header component

## Testing
- [ ] Verify both migrated pages render correctly
- [ ] Check icon and background colors display properly
- [ ] Confirm subtitle is optional and displays when provided
- [ ] Test responsive behavior on mobile/tablet/desktop

Closes #446