### PR TITLE
refactor: create SecondaryLink component and migrate 3 pages (#449)

### DIFF
--- a/Front-end/src/app/login/page.tsx
+++ b/Front-end/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import "../../utils/styles/global.css";
-import { H1, Button, TextBox, PageLayout, AlertBox } from '@/components';
+import { H1, Button, TextBox, PageLayout, AlertBox, SecondaryLink } from '@/components';
 
 
 
@@ -71,17 +71,11 @@ export default function LoginPage() {
         </form>
 
         {/* Secondary sign up link */}
-        <div className="text-center">
-          <p className="text-gray-400 text-sm">
-            Don't have an account?{" "}
-            <Link 
-              href="/sign-up" 
-              className="text-green-400 hover:text-green-300 underline transition-colors duration-200"
-            >
-              Sign up
-            </Link>
-          </p>
-        </div>
+        <SecondaryLink
+          promptText="Don't have an account?"
+          linkText="Sign up"
+          href="/sign-up"
+        />
     </PageLayout>
   );
 }

--- a/Front-end/src/app/reset-password/page.tsx
+++ b/Front-end/src/app/reset-password/page.tsx
@@ -4,7 +4,7 @@ import { resetPassword } from "./actions";
 import "../../utils/styles/global.css";
 import Link from "next/link";
 import { useState, FormEvent, use } from "react";
-import { H1, Button, PageLayout } from "@/components";
+import { H1, Button, PageLayout, SecondaryLink } from "@/components";
 
 
 export default function ResetPasswordPage({
@@ -180,17 +180,11 @@ export default function ResetPasswordPage({
         </form>
         
         {/* Secondary link */}
-        <div className="text-center">
-          <p className="text-gray-400 text-sm">
-            Remember your password?{" "}
-            <Link
-              href="/login"
-              className="text-green-400 hover:text-green-300 underline transition-colors duration-200"
-            >
-              Log in
-            </Link>
-          </p>
-        </div>
+        <SecondaryLink
+          promptText="Remember your password?"
+          linkText="Log in"
+          href="/login"
+        />
     </PageLayout>
   );
 }

--- a/Front-end/src/app/sign-up/page.tsx
+++ b/Front-end/src/app/sign-up/page.tsx
@@ -4,7 +4,7 @@ import { signup } from "./actions";
 import "../../utils/styles/global.css";
 import Link from "next/link";
 import { useState, FormEvent } from "react";
-import { H1, TextBox, Button, PageLayout } from "@/components";
+import { H1, TextBox, Button, PageLayout, SecondaryLink } from "@/components";
 
 export default function SignUpPage() {
   // State for form fields
@@ -97,17 +97,11 @@ export default function SignUpPage() {
         </form>
         
         {/* Secondary sign up link */}
-        <div className="text-center">
-          <p className="text-gray-400 text-sm">
-            Already have an account?{" "}
-            <Link
-              href="/login"
-              className="text-green-400 hover:text-green-300 underline transition-colors duration-200"
-            >
-              Log in
-            </Link>
-          </p>
-        </div>
+        <SecondaryLink
+          promptText="Already have an account?"
+          linkText="Log in"
+          href="/login"
+        />
     </PageLayout>
   );
 }

--- a/Front-end/src/components/SecondaryLink.tsx
+++ b/Front-end/src/components/SecondaryLink.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+interface SecondaryLinkProps {
+  promptText: string;
+  linkText: string;
+  href: string;
+  className?: string;
+}
+
+export default function SecondaryLink({
+  promptText,
+  linkText,
+  href,
+  className = ""
+}: SecondaryLinkProps) {
+  return (
+    <div className={`text-center ${className}`}>
+      <p className="text-gray-400 text-sm">
+        {promptText}{" "}
+        <Link
+          href={href}
+          className="text-green-400 hover:text-green-300 underline transition-colors duration-200"
+        >
+          {linkText}
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/Front-end/src/components/index.tsx
+++ b/Front-end/src/components/index.tsx
@@ -12,6 +12,7 @@ export { default as Loading } from './Loading';
 export { default as PageHeader } from './PageHeader';
 export { default as PageLayout } from './PageLayout';
 export { default as PopupBanner } from './PopupBanner';
+export { default as SecondaryLink } from './SecondaryLink';
 export { default as StatCard } from './StatCard';
 export { default as StreakCalendar } from './StreakCalendar';
 export { default as StreakCell } from './StreakCell';


### PR DESCRIPTION
## Summary
Created a centralized SecondaryLink component for consistent secondary navigation link styling across authentication pages.

## Changes
- Created `SecondaryLink.tsx` component with configurable props:
  - promptText: introductory text (e.g., "Don't have an account?")
  - linkText: clickable link text (e.g., "Sign up")
  - href: link destination
  - className: additional custom styling support

- Migrated 3 pages to use SecondaryLink:
  - login/page.tsx ("Don't have an account? Sign up")
  - sign-up/page.tsx ("Already have an account? Log in")
  - reset-password/page.tsx ("Remember your password? Log in")

- Updated components/index.tsx to export SecondaryLink

## Impact
- Eliminated ~10 lines of duplicate code per page (~30 lines total)
- Improved consistency across secondary navigation links
- Easier to update link styling across all auth pages

## Testing
- [ ] Verify all 3 pages render secondary links correctly
- [ ] Check link hover states and transitions
- [ ] Confirm navigation works to correct destinations

Closes #449