### PR TITLE
Create useMounted hook for SSR-safe mounting checks

### DIFF
--- a/Front-end/src/app/contact/page.tsx
+++ b/Front-end/src/app/contact/page.tsx
@@ -1,16 +1,13 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { HiOutlineMail, HiOutlineGlobeAlt } from "react-icons/hi";
 import { FaGithub, FaTwitter, FaLinkedin } from "react-icons/fa";
 import { Button, H1, Container, Loading, PageLayout, PageHeader }  from "@/components";
+import { useMounted } from "@/hooks";
 
 export default function Contact() {
-  const [mounted, setMounted] = useState(false);
+  const mounted = useMounted();
   const [emailCopied, setEmailCopied] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   const handleCopyEmail = async () => {
     try {

--- a/Front-end/src/app/get-started/page.tsx
+++ b/Front-end/src/app/get-started/page.tsx
@@ -1,18 +1,15 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { HiOutlinePencil } from "react-icons/hi2";
 import { IoIosCloseCircleOutline, IoIosCheckmarkCircle } from "react-icons/io";
 import { useRouter } from "next/navigation";
 import { H1, Container, Button, Loading, PageLayout }  from "@/components";
+import { useMounted } from "@/hooks";
 
 export default function GettingStarted() {
   const [currentStep, setCurrentStep] = useState(0);
-  const [mounted, setMounted] = useState(false);
-
+  const mounted = useMounted();
   const router = useRouter();
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   const steps = [
     {

--- a/Front-end/src/app/report-bug/page.tsx
+++ b/Front-end/src/app/report-bug/page.tsx
@@ -1,13 +1,14 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { HiOutlineCamera, HiOutlineInformationCircle } from "react-icons/hi";
 import { FaBug } from "react-icons/fa";
 import { createClient } from "@/utils/supabase/client";
 import { H1, TextBox, Container, Button, Loading, PageLayout, PageHeader, AlertBox } from "@/components";
+import { useMounted } from "@/hooks";
 
 export default function BugReport() {
   const supabase = createClient();
-  const [mounted, setMounted] = useState(false);
+  const mounted = useMounted();
   const [formData, setFormData] = useState({
     title: "",
     description: "",
@@ -19,10 +20,6 @@ export default function BugReport() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitSuccess, setSubmitSuccess] = useState(false);
   const [submitError, setSubmitError] = useState("");
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target;

--- a/Front-end/src/app/welcome/page.tsx
+++ b/Front-end/src/app/welcome/page.tsx
@@ -1,16 +1,12 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
 import { H1, Container, Button, Loading, PageLayout } from "@/components";
+import { useMounted } from "@/hooks";
 import "../../utils/styles/global.css";
 
 export default function Welcome() {
   const router = useRouter();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const mounted = useMounted();
 
   const handleGetStarted = () => {
     router.push("/get-started");

--- a/Front-end/src/hooks/index.ts
+++ b/Front-end/src/hooks/index.ts
@@ -1,2 +1,5 @@
 // Authentication hooks
 export { useSupabaseAuth } from './auth/useSupabaseAuth';
+
+// UI hooks
+export { useMounted } from './ui/useMounted';

--- a/Front-end/src/hooks/ui/useMounted.ts
+++ b/Front-end/src/hooks/ui/useMounted.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook to check if component is mounted on the client
+ *
+ * Returns false during SSR and true after component mounts on client.
+ * Useful for preventing hydration mismatches when using browser-only APIs.
+ *
+ * @returns {boolean} True if component is mounted on client, false during SSR
+ *
+ * @example
+ * function MyComponent() {
+ *   const mounted = useMounted();
+ *
+ *   if (!mounted) {
+ *     return <Loading />;
+ *   }
+ *
+ *   // Safe to use browser APIs here
+ *   return <div>{window.innerWidth}</div>;
+ * }
+ */
+export function useMounted(): boolean {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return mounted;
+}


### PR DESCRIPTION
## Overview
Extracts client-side mounting check logic into a reusable custom hook for SSR safety.

## Changes

### New Hook: `useMounted`
Created in `src/hooks/ui/useMounted.ts` with:
- ✅ SSR-safe implementation
- ✅ Returns false during SSR, true after client mount
- ✅ Prevents hydration mismatches
- ✅ Simple boolean return value
- ✅ Full TypeScript types
- ✅ Comprehensive JSDoc documentation

### Hook API
```typescript
useMounted()
// Returns: boolean (true when mounted on client)
```

### Pages Migrated
- **contact/page.tsx** - Removed 6 lines
- **welcome/page.tsx** - Removed 6 lines
- **get-started/page.tsx** - Removed 6 lines
- **report-bug/page.tsx** - Removed 7 lines

**Total:** ~25 lines of duplicated code eliminated

## Benefits
- ✓ Consistent SSR handling across all pages
- ✓ Simple, reusable pattern
- ✓ No behavior changes - exact same functionality preserved
- ✓ Easier maintenance

## Testing
- ✅ Build completes successfully
- ✅ No TypeScript errors
- ✅ All 4 migrated pages work correctly
- ✅ SSR behavior unchanged

Closes #461