### PR TITLE
fix: close mobile navigation menu on route change

### DIFF
--- a/Front-end/src/components/AppHeader.tsx
+++ b/Front-end/src/components/AppHeader.tsx
@@ -52,6 +52,11 @@ export default function AppHeader() {
     fetchUsername();
   }, [user?.id, supabase]);
 
+  // Close mobile menu when route changes
+  useEffect(() => {
+    setMobileMenuOpen(false);
+  }, [pathname]);
+
   // Define your navigation structure
   const navItems: NavItem[] = [
     { href: "/", label: "Home", authRequired: false},


### PR DESCRIPTION
Automatically close the mobile hamburger menu when the user navigates to a new page. This handles all navigation scenarios including:
- Clicking menu items
- Browser back/forward buttons
- Programmatic navigation

Added useEffect hook that listens to pathname changes and sets mobileMenuOpen to false when the route changes.

Fixes #511

