### PR TITLE
feat: add GitHub Actions workflow for daily email reminders

### DIFF
--- a/.github/workflows/daily-email-reminders.yml
+++ b/.github/workflows/daily-email-reminders.yml
@@ -1,0 +1,20 @@
+name: Send Daily Email Reminders
+
+on:
+  schedule:
+    # Run every day at 8 PM UTC (adjust as needed for different timezones)
+    # The function itself will check each user's timezone and reminder time
+    # Run every hour to catch all timezones
+    - cron: '0 * * * *'  # Every hour
+  workflow_dispatch:  # Allow manual triggering for testing
+
+jobs:
+  send-reminders:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Supabase Edge Function
+        run: |
+          curl -X POST "${{ secrets.SUPABASE_FUNCTION_URL }}" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_ANON_KEY }}" \
+            -H "Content-Type: application/json"

--- a/scripts/disable-email-notifications.sql
+++ b/scripts/disable-email-notifications.sql
@@ -1,0 +1,14 @@
+-- Disable email notifications for all users
+-- Run this in the Supabase SQL Editor if you want to turn off emails temporarily
+
+UPDATE notification_preferences
+SET
+  email_enabled = false,
+  daily_reminder_enabled = false;
+
+-- Verify the changes
+SELECT
+  COUNT(*) as total_users,
+  SUM(CASE WHEN email_enabled THEN 1 ELSE 0 END) as email_enabled_count,
+  SUM(CASE WHEN daily_reminder_enabled THEN 1 ELSE 0 END) as daily_reminder_enabled_count
+FROM notification_preferences;

--- a/scripts/enable-email-notifications.sql
+++ b/scripts/enable-email-notifications.sql
@@ -1,0 +1,41 @@
+-- Enable email notifications for all users
+-- Run this in the Supabase SQL Editor
+
+-- Step 1: Update existing notification_preferences to enable email notifications
+UPDATE notification_preferences
+SET
+  email_enabled = true,
+  daily_reminder_enabled = true,
+  reminder_if_incomplete_enabled = true,
+  reminder_if_none_enabled = true
+WHERE email_enabled = false OR daily_reminder_enabled = false;
+
+-- Step 2: Create notification_preferences for users who don't have them yet
+-- This ensures all users in user_profiles have notification preferences
+INSERT INTO notification_preferences (
+  user_id,
+  email_enabled,
+  daily_reminder_enabled,
+  reminder_if_incomplete_enabled,
+  reminder_if_none_enabled,
+  reminder_time,
+  timezone
+)
+SELECT
+  id,
+  true,  -- email_enabled
+  true,  -- daily_reminder_enabled
+  true,  -- reminder_if_incomplete_enabled
+  true,  -- reminder_if_none_enabled
+  '20:00:00',  -- Default reminder time: 8 PM
+  'America/New_York'  -- Default timezone
+FROM user_profiles
+WHERE id NOT IN (SELECT user_id FROM notification_preferences)
+ON CONFLICT (user_id) DO NOTHING;
+
+-- Step 3: Verify the changes
+SELECT
+  COUNT(*) as total_users,
+  SUM(CASE WHEN email_enabled THEN 1 ELSE 0 END) as email_enabled_count,
+  SUM(CASE WHEN daily_reminder_enabled THEN 1 ELSE 0 END) as daily_reminder_enabled_count
+FROM notification_preferences;


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to run email reminders every hour
- Ensures users get emails at their configured reminder time across all timezones
- Triggers Supabase Edge Function automatically

## Setup Required
After merging, add these GitHub secrets in Settings > Secrets and variables > Actions:
- `SUPABASE_FUNCTION_URL` - URL to your Supabase edge function
- `SUPABASE_ANON_KEY` - Your Supabase anonymous key

(Keys should be added via GitHub Secrets UI, not documented here)

## Test Plan
- [ ] Merge PR
- [ ] Add GitHub secrets via Settings
- [ ] Wait for next hourly cron run (or trigger manually via Actions tab)
- [ ] Check function logs in Supabase dashboard