### PR TITLE
feat: implement complete forgot/reset password flow

### DIFF
--- a/Front-end/next.config.ts
+++ b/Front-end/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  turbopack: {
+    root: __dirname,
+  },
   images: {
     remotePatterns: [
       {

--- a/Front-end/src/app/auth/callback/route.ts
+++ b/Front-end/src/app/auth/callback/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { redirect } from 'next/navigation'
+import { createClient } from '@/utils/supabase/server'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const code = searchParams.get('code')
+  const next = searchParams.get('next') ?? '/reset-password'
+
+  if (code) {
+    const supabase = await createClient()
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (!error) {
+      return NextResponse.redirect(new URL(next, request.url))
+    }
+  }
+
+  return NextResponse.redirect(new URL('/forgot-password?error=link_expired', request.url))
+}

--- a/Front-end/src/app/forgot-password/actions.ts
+++ b/Front-end/src/app/forgot-password/actions.ts
@@ -1,0 +1,20 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { headers } from 'next/headers'
+import { createClient } from '@/utils/supabase/server'
+
+export async function requestPasswordReset(formData: FormData) {
+  const supabase = await createClient()
+
+  const email = formData.get('email') as string
+
+  const headersList = await headers()
+  const origin = headersList.get('origin') ?? process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3001'
+  const redirectTo = `${origin}/auth/callback?next=/reset-password`
+
+  await supabase.auth.resetPasswordForEmail(email, { redirectTo })
+
+  // Always redirect with sent=true to avoid email enumeration
+  redirect('/forgot-password?sent=true')
+}

--- a/Front-end/src/app/forgot-password/page.tsx
+++ b/Front-end/src/app/forgot-password/page.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { use } from 'react'
+import { requestPasswordReset } from './actions'
+import '../../utils/styles/global.css'
+import { H1, Button, TextBox, PageLayout, AlertBox, SecondaryLink } from '@/components'
+import { useForm } from '@/hooks'
+
+interface ForgotPasswordForm {
+  email: string
+}
+
+export default function ForgotPasswordPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ sent?: string; error?: string }>
+}) {
+  const params = use(searchParams)
+
+  const { values, errors, handleChange, handleSubmit, isSubmitting } = useForm<ForgotPasswordForm>({
+    initialValues: { email: '' },
+    onSubmit: async (formValues) => {
+      const formData = new FormData()
+      formData.append('email', formValues.email)
+      await requestPasswordReset(formData)
+    },
+    validate: (values) => {
+      const errors: Partial<Record<keyof ForgotPasswordForm, string>> = {}
+      if (!values.email) errors.email = 'Email is required'
+      return errors
+    },
+  })
+
+  if (params.sent === 'true') {
+    return (
+      <PageLayout maxWidth="sm">
+        <H1 text="Check Your Inbox" />
+        <AlertBox type="success" className="mb-4">
+          If an account exists for that email, you'll receive a reset link shortly.
+        </AlertBox>
+        <SecondaryLink
+          promptText="Remember your password?"
+          linkText="Log in"
+          href="/login"
+        />
+      </PageLayout>
+    )
+  }
+
+  return (
+    <PageLayout maxWidth="sm">
+      <H1 text="Forgot Password" />
+
+      {params.error === 'link_expired' && (
+        <AlertBox type="error" className="mb-4">
+          That reset link has expired. Please request a new one.
+        </AlertBox>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        <TextBox
+          label="Email"
+          type="email"
+          name="email"
+          id="email"
+          value={values.email}
+          onChange={handleChange}
+          required
+          error={!!errors.email}
+          errorMessage={errors.email}
+        />
+
+        <div style={{ marginTop: '1.5rem', marginBottom: '1rem' }}>
+          <Button htmlType="submit" type="primary" disabled={isSubmitting} fullWidth>
+            {isSubmitting ? 'Sending...' : 'Send Reset Link'}
+          </Button>
+        </div>
+      </form>
+
+      <SecondaryLink
+        promptText="Remember your password?"
+        linkText="Log in"
+        href="/login"
+      />
+    </PageLayout>
+  )
+}

--- a/Front-end/src/app/login/page.tsx
+++ b/Front-end/src/app/login/page.tsx
@@ -2,7 +2,7 @@
 import { useAuth } from "../../context/AuthContext";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, use } from "react";
 import "../../utils/styles/global.css";
 import { H1, Button, TextBox, PageLayout, AlertBox, SecondaryLink } from '@/components';
 import { useForm } from '@/hooks';
@@ -14,7 +14,12 @@ interface LoginForm {
   password: string;
 }
 
-export default function LoginPage() {
+export default function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ message?: string }>
+}) {
+  const params = use(searchParams);
   const { signIn, loading: authLoading } = useAuth();
   const router = useRouter();
   const [error, setError] = useState("");
@@ -48,12 +53,18 @@ export default function LoginPage() {
 
 
         <form onSubmit={handleSubmit}>
+          {params.message === 'password_reset_success' && (
+            <AlertBox type="success" className="mb-4">
+              Password reset successfully. Please log in.
+            </AlertBox>
+          )}
+
           {error && (
             <AlertBox type="error" className="mb-4">
               {error}
             </AlertBox>
           )}
-          
+
           <TextBox
             label="Email"
             type="email"
@@ -76,6 +87,12 @@ export default function LoginPage() {
             required
             showPasswordToggle
           />
+
+          <div style={{ textAlign: "right", marginBottom: "1rem", marginTop: "-0.5rem" }}>
+            <Link href="/forgot-password" style={{ fontSize: "0.875rem", color: "#16a34a" }}>
+              Forgot password?
+            </Link>
+          </div>
 
           {/* Large prominent login button */}
 

--- a/Front-end/src/app/reset-password/page.tsx
+++ b/Front-end/src/app/reset-password/page.tsx
@@ -2,9 +2,8 @@
 
 import { resetPassword } from "./actions";
 import "../../utils/styles/global.css";
-import Link from "next/link";
-import { useState, FormEvent, use } from "react";
-import { H1, Button, PageLayout, SecondaryLink } from "@/components";
+import { use } from "react";
+import { H1, Button, TextBox, PageLayout, AlertBox, SecondaryLink } from "@/components";
 import { useForm } from "@/hooks";
 
 interface ResetPasswordForm {
@@ -17,12 +16,7 @@ export default function ResetPasswordPage({
 }: {
   searchParams: Promise<{ error?: string; message?: string }>
 }) {
-  // Unwrap searchParams
   const params = use(searchParams);
-
-  // State for show/hide password toggles
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const { values, errors, handleChange, handleSubmit, isSubmitting } = useForm<ResetPasswordForm>({
     initialValues: {
@@ -30,11 +24,9 @@ export default function ResetPasswordPage({
       confirm_password: ''
     },
     onSubmit: async (formValues) => {
-      // Create FormData for server action
       const formData = new FormData();
       formData.append('password', formValues.password);
       formData.append('confirm_password', formValues.confirm_password);
-
       await resetPassword(formData);
     },
     validate: (values) => {
@@ -49,9 +41,8 @@ export default function ResetPasswordPage({
     }
   });
 
-  // Derived state for UI feedback
   const passwordsMatch = values.password === values.confirm_password && values.confirm_password !== '';
-  const showError = values.confirm_password !== '' && !passwordsMatch;
+  const showConfirmError = values.confirm_password !== '' && !passwordsMatch;
 
   const getErrorMessage = (error?: string) => {
     switch (error) {
@@ -72,132 +63,56 @@ export default function ResetPasswordPage({
     <PageLayout maxWidth="sm">
       <H1 text="Reset Password" />
 
+      {errorMessage && (
+        <AlertBox type="error" className="mb-4">
+          {errorMessage}
+        </AlertBox>
+      )}
 
-        {errorMessage && (
-          <div style={{
-            backgroundColor: "#fef2f2",
-            border: "1px solid #dc2626",
-            borderRadius: "4px",
-            padding: "0.75rem",
-            marginBottom: "1rem"
-          }}>
-            <p style={{ color: "#dc2626", fontSize: "0.875rem", margin: 0 }}>
-              {errorMessage}
-            </p>
-          </div>
-        )}
-
-        <form onSubmit={handleSubmit}>
-          {/* Password */}
-          <div style={{ marginBottom: "1rem" }}>
-            <label htmlFor="password">New Password</label>
-            <div style={{ position: "relative" }}>
-              <input
-                id="password"
-                type={showPassword ? "text" : "password"}
-                name="password"
-                value={values.password}
-                onChange={handleChange}
-                required
-                minLength={6}
-                style={{
-                  width: "100%",
-                  padding: "0.5rem",
-                  paddingRight: "4rem",
-                  borderRadius: "4px",
-                  border: "1px solid #ccc",
-                  marginTop: "0.25rem",
-                }}
-                className="text-black"
-              />
-              <button
-                type="button"
-                onClick={() => setShowPassword(!showPassword)}
-                style={{
-                  position: "absolute",
-                  right: "0.5rem",
-                  top: "50%",
-                  transform: "translateY(-50%)",
-                  padding: "0.25rem 0.5rem",
-                  fontSize: "0.875rem",
-                  color: "#16a34a",
-                  background: "transparent",
-                  border: "none",
-                  cursor: "pointer",
-                }}
-              >
-                {showPassword ? "Hide" : "Show"}
-              </button>
-            </div>
-          </div>
-
-          {/* Confirm Password */}
-          <div style={{ marginBottom: "1rem" }}>
-            <label htmlFor="confirm_password">Confirm New Password</label>
-            <div style={{ position: "relative" }}>
-              <input
-                id="confirm_password"
-                type={showConfirmPassword ? "text" : "password"}
-                name="confirm_password"
-                value={values.confirm_password}
-                onChange={handleChange}
-                required
-                minLength={6}
-                style={{
-                  width: "100%",
-                  padding: "0.5rem",
-                  paddingRight: "4rem",
-                  borderRadius: "4px",
-                  border: showError || errors.confirm_password ? "1px solid #dc2626" : "1px solid #ccc",
-                  marginTop: "0.25rem",
-                }}
-                className="text-black"
-              />
-              <button
-                type="button"
-                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                style={{
-                  position: "absolute",
-                  right: "0.5rem",
-                  top: "50%",
-                  transform: "translateY(-50%)",
-                  padding: "0.25rem 0.5rem",
-                  fontSize: "0.875rem",
-                  color: "#16a34a",
-                  background: "transparent",
-                  border: "none",
-                  cursor: "pointer",
-                }}
-              >
-                {showConfirmPassword ? "Hide" : "Show"}
-              </button>
-            </div>
-            {(showError || errors.confirm_password) && (
-              <p style={{ color: "#dc2626", fontSize: "0.875rem", marginTop: "0.25rem" }}>
-                {errors.confirm_password || "Passwords do not match"}
-              </p>
-            )}
-          </div>
-
-          {/* Submit */}
-          <div style={{ marginTop: "1.5rem", marginBottom: "1rem" }}>
-            <Button
-              htmlType="submit"
-              type="primary"
-              disabled={!passwordsMatch || isSubmitting}
-              fullWidth
-            >
-              {isSubmitting ? "Resetting..." : "Reset Password"}
-            </Button>
-          </div>
-        </form>
-        
-        {/* Secondary link */}
-        <SecondaryLink
-          promptText="Remember your password?"
-          linkText="Log in"
-          href="/login"
+      <form onSubmit={handleSubmit}>
+        <TextBox
+          label="New Password"
+          type="password"
+          name="password"
+          id="password"
+          value={values.password}
+          onChange={handleChange}
+          required
+          showPasswordToggle
+          error={!!errors.password}
+          errorMessage={errors.password}
         />
+
+        <TextBox
+          label="Confirm New Password"
+          type="password"
+          name="confirm_password"
+          id="confirm_password"
+          value={values.confirm_password}
+          onChange={handleChange}
+          required
+          showPasswordToggle
+          error={showConfirmError || !!errors.confirm_password}
+          errorMessage={errors.confirm_password || "Passwords do not match"}
+        />
+
+        <div style={{ marginTop: "1.5rem", marginBottom: "1rem" }}>
+          <Button
+            htmlType="submit"
+            type="primary"
+            disabled={!passwordsMatch || isSubmitting}
+            fullWidth
+          >
+            {isSubmitting ? "Resetting..." : "Reset Password"}
+          </Button>
+        </div>
+      </form>
+
+      <SecondaryLink
+        promptText="Remember your password?"
+        linkText="Log in"
+        href="/login"
+      />
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary

Wires up the complete end-to-end password reset flow that was previously missing the first half. Users can now request a reset email from the login page and complete the full flow through to a new password.

**Full flow:**
```
Login page → "Forgot password?" link
  → /forgot-password (enter email → inline success state)
    → Supabase sends email → /auth/callback?code=xxx&next=/reset-password
      → exchanges code for session → /reset-password
        → user sets new password → /login?message=password_reset_success
          → green success banner on login page
```

## Changes

### New files
- **`/forgot-password/page.tsx`** — Email entry form with inline success state (no separate confirmation page). Shows same success message for valid and invalid emails to prevent email enumeration.
- **`/forgot-password/actions.ts`** — Server action that calls `resetPasswordForEmail`. Derives `redirectTo` from the request `origin` header for reliability across environments (no env var dependency). Always redirects with `?sent=true`.
- **`/auth/callback/route.ts`** — Route handler that exchanges the Supabase PKCE code for a session, then redirects to `/reset-password`. On failure redirects to `/forgot-password?error=link_expired`.

### Modified files
- **`/login/page.tsx`** — Added `searchParams` prop, green `AlertBox` success banner when `?message=password_reset_success`, and "Forgot password?" link between the password field and submit button.
- **`/reset-password/page.tsx`** — Refactored raw `<input>` elements to `TextBox` with `showPasswordToggle`, replaced inline error div with `AlertBox type="error"`, removed manual show/hide password state.
- **`next.config.ts`** — Added `turbopack.root` to resolve multiple lockfile workspace warning.

## Environment setup required

Add to `.env.local` (already done locally — do **not** commit actual values):
```
NEXT_PUBLIC_SITE_URL=http://localhost:3001
```

For production, set `NEXT_PUBLIC_SITE_URL=https://grainsofsand.app` in your hosting environment.

**Supabase configuration needed:**
- Authentication → URL Configuration → Redirect URLs — add:
  - `http://localhost:3001/**`
  - `https://grainsofsand.app/**`

## Test plan

- [ ] Navigate to `/login` — confirm "Forgot password?" link appears between password field and login button
- [ ] Click "Forgot password?" → confirm `/forgot-password` page loads with email form
- [ ] Submit a valid email → confirm inline "Check your inbox" success state appears (no page change)
- [ ] Submit an invalid/nonexistent email → confirm same success state (no email enumeration)
- [ ] Click reset link in email → confirm redirect lands on `/reset-password`
- [ ] Enter mismatched passwords → confirm inline validation error
- [ ] Enter valid matching passwords (min 6 chars) → submit → confirm redirect to `/login` with green success banner
- [ ] Confirm `/reset-password` page visually matches login/sign-up pages (TextBox components, no raw inputs)
- [ ] Confirm clicking an expired reset link redirects to `/forgot-password?error=link_expired` with error message