### PR TITLE
fix: improve reminder email dark/light mode and add single-user test targeting

### DIFF
--- a/supabase/functions/send-daily-reminders-test/index.ts
+++ b/supabase/functions/send-daily-reminders-test/index.ts
@@ -1,0 +1,488 @@
+// @ts-nocheck - Deno Edge Function (uses Deno runtime, not Node.js)
+// TEST VERSION - Bypasses time checks for debugging
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.50.2';
+import { Resend } from 'https://esm.sh/resend@3.2.0';
+import { getEmailContent } from '../send-daily-reminders/messages.ts';
+
+// CORS headers for allowing requests
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+interface HabitCompletionStatus {
+  totalHabits: number;
+  completedToday: number;
+  status: 'all' | 'some' | 'none';
+}
+
+interface UserToNotify {
+  user_id: string;
+  email: string;
+  username: string;
+  reminder_if_incomplete_enabled: boolean;
+  reminder_if_none_enabled: boolean;
+  reminder_time: string;
+  timezone: string;
+}
+
+/**
+ * TEST VERSION - Main handler for daily habit reminder emails
+ * This version BYPASSES time checks for testing purposes
+ */
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    console.log('🧪 TEST MODE: Starting daily habit reminder job (time checks DISABLED)...');
+
+    // Parse optional test_email from request body — if provided, only send to that address
+    let testEmail: string | null = null;
+    if (req.method === 'POST') {
+      try {
+        const body = await req.json();
+        testEmail = body.test_email ?? null;
+      } catch {
+        // No body or invalid JSON, proceed normally
+      }
+    }
+    if (testEmail) {
+      console.log(`🎯 Targeting single email: ${testEmail}`);
+    }
+
+    // Initialize Supabase client with service role key
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const resendApiKey = Deno.env.get('RESEND_API_KEY')!;
+
+    if (!resendApiKey) {
+      throw new Error('RESEND_API_KEY environment variable is not set');
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const resend = new Resend(resendApiKey);
+
+    // Get today's date in YYYY-MM-DD format
+    const today = new Date().toLocaleDateString('en-CA');
+    console.log(`Processing reminders for date: ${today}`);
+
+    // Step 1: Get all users who have email notifications enabled
+    const { data: notificationPrefs, error: prefsError } = await supabase
+      .from('notification_preferences')
+      .select('user_id, reminder_if_incomplete_enabled, reminder_if_none_enabled, reminder_time, timezone')
+      .eq('email_enabled', true)
+      .eq('daily_reminder_enabled', true);
+
+    if (prefsError) {
+      console.error('Error fetching notification preferences:', prefsError);
+      throw prefsError;
+    }
+
+    if (!notificationPrefs || notificationPrefs.length === 0) {
+      console.log('No users with email notifications enabled');
+      return new Response(
+        JSON.stringify({ message: 'No users to notify' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
+      );
+    }
+
+    console.log(`✅ Found ${notificationPrefs.length} users with notifications enabled`);
+
+    // Step 2: Get user emails and usernames
+    const usersToNotify: UserToNotify[] = [];
+
+    for (const pref of notificationPrefs) {
+      try {
+        // Get user email from auth.users
+        const { data: authData, error: authError } = await supabase.auth.admin.getUserById(pref.user_id);
+
+        if (authError || !authData.user || !authData.user.email) {
+          console.log(`⚠️ Skipping user ${pref.user_id} - no email found`);
+          continue;
+        }
+
+        // Get username from user_profiles
+        const { data: profileData, error: profileError } = await supabase
+          .from('user_profiles')
+          .select('username')
+          .eq('id', pref.user_id)
+          .single();
+
+        if (profileError || !profileData) {
+          console.log(`⚠️ Skipping user ${pref.user_id} - no profile found`);
+          continue;
+        }
+
+        usersToNotify.push({
+          user_id: pref.user_id,
+          email: authData.user.email,
+          username: profileData.username,
+          reminder_if_incomplete_enabled: pref.reminder_if_incomplete_enabled,
+          reminder_if_none_enabled: pref.reminder_if_none_enabled,
+          reminder_time: pref.reminder_time,
+          timezone: pref.timezone,
+        });
+
+        console.log(`✅ Added user: ${profileData.username} (${authData.user.email})`);
+      } catch (err) {
+        console.error(`Error processing user ${pref.user_id}:`, err);
+      }
+    }
+
+    // Filter to single user if test_email provided
+    if (testEmail) {
+      const filtered = usersToNotify.filter(u => u.email === testEmail);
+      if (filtered.length === 0) {
+        return new Response(
+          JSON.stringify({ error: `No notification-enabled user found with email: ${testEmail}` }),
+          { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 404 }
+        );
+      }
+      usersToNotify.length = 0;
+      usersToNotify.push(...filtered);
+    }
+
+    console.log(`\n📧 Processing ${usersToNotify.length} users for habit completion status\n`);
+
+    // Step 3: For each user, check habits and send email (NO TIME CHECK)
+    let emailsSent = 0;
+    let emailsSkipped = 0;
+    const skipReasons: Record<string, number> = {
+      allCompleted: 0,
+      noHabits: 0,
+      preferencesDisabled: 0,
+    };
+
+    for (const user of usersToNotify) {
+      try {
+        console.log(`\n👤 Processing user: ${user.username}`);
+
+        // Get habit completion status
+        const status = await getHabitCompletionStatus(supabase, user.user_id, today);
+
+        console.log(`   📊 Habits: ${status.completedToday}/${status.totalHabits} completed (status: ${status.status})`);
+        console.log(`   ⚙️ Preferences: incomplete=${user.reminder_if_incomplete_enabled}, none=${user.reminder_if_none_enabled}`);
+
+        // Determine if we should send an email
+        const shouldSend = shouldSendEmail(user, status);
+
+        if (!shouldSend) {
+          let reason = 'unknown';
+          if (status.status === 'all') {
+            reason = 'all habits completed';
+            skipReasons.allCompleted++;
+          } else if (status.totalHabits === 0) {
+            reason = 'no active habits';
+            skipReasons.noHabits++;
+          } else if (status.status === 'none' && !user.reminder_if_none_enabled) {
+            reason = 'none reminder disabled';
+            skipReasons.preferencesDisabled++;
+          } else if (status.status === 'some' && !user.reminder_if_incomplete_enabled) {
+            reason = 'incomplete reminder disabled';
+            skipReasons.preferencesDisabled++;
+          }
+
+          console.log(`   ⏭️ SKIPPED: ${reason}`);
+          emailsSkipped++;
+          continue;
+        }
+
+        // Determine email type
+        const emailType = status.status === 'none' ? 'none' : 'incomplete';
+
+        // Get email content with random funny message
+        const { subject, message } = getEmailContent(emailType);
+
+        console.log(`   📨 Sending ${emailType} email...`);
+        console.log(`   📧 Subject: ${subject}`);
+
+        // Send email via Resend
+        await sendReminderEmail(
+          resend,
+          user.email,
+          user.username,
+          subject,
+          message,
+          status
+        );
+
+        console.log(`   ✅ Email sent successfully!`);
+        emailsSent++;
+
+      } catch (err) {
+        console.error(`   ❌ Error processing user ${user.username}:`, err);
+      }
+    }
+
+    console.log(`\n📊 Job Summary:`);
+    console.log(`   Total users: ${usersToNotify.length}`);
+    console.log(`   Emails sent: ${emailsSent}`);
+    console.log(`   Emails skipped: ${emailsSkipped}`);
+    console.log(`   Skip reasons:`);
+    console.log(`     - All habits completed: ${skipReasons.allCompleted}`);
+    console.log(`     - No active habits: ${skipReasons.noHabits}`);
+    console.log(`     - Preferences disabled: ${skipReasons.preferencesDisabled}`);
+
+    return new Response(
+      JSON.stringify({
+        message: 'TEST MODE: Daily reminders processed (time checks disabled)',
+        emailsSent,
+        emailsSkipped,
+        totalUsers: usersToNotify.length,
+        skipReasons,
+      }),
+      {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 200,
+      }
+    );
+
+  } catch (error) {
+    console.error('❌ Error in daily reminder function:', error);
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 500,
+      }
+    );
+  }
+});
+
+/**
+ * Get habit completion status for a user on a specific date
+ */
+async function getHabitCompletionStatus(
+  supabase: any,
+  userId: string,
+  date: string
+): Promise<HabitCompletionStatus> {
+  // Get total active habits (not archived)
+  const { data: habits, error: habitsError } = await supabase
+    .from('habits')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('is_archived', false);
+
+  if (habitsError) {
+    console.error('Error fetching habits:', habitsError);
+    throw habitsError;
+  }
+
+  const totalHabits = habits?.length ?? 0;
+
+  // Get today's completions
+  const { data: completions, error: completionsError } = await supabase
+    .from('habit_completions')
+    .select('habit_id')
+    .eq('user_id', userId)
+    .eq('completion_date', date);
+
+  if (completionsError) {
+    console.error('Error fetching completions:', completionsError);
+    throw completionsError;
+  }
+
+  const completedToday = completions?.length ?? 0;
+
+  // Determine status
+  let status: 'all' | 'some' | 'none';
+  if (totalHabits === 0 || completedToday === 0) {
+    status = 'none';
+  } else if (completedToday === totalHabits) {
+    status = 'all';
+  } else {
+    status = 'some';
+  }
+
+  return {
+    totalHabits,
+    completedToday,
+    status,
+  };
+}
+
+/**
+ * Determine if we should send an email to this user based on their preferences and status
+ */
+function shouldSendEmail(user: UserToNotify, status: HabitCompletionStatus): boolean {
+  // Don't send if all habits completed
+  if (status.status === 'all') {
+    return false;
+  }
+
+  // Don't send if user has no habits
+  if (status.totalHabits === 0) {
+    return false;
+  }
+
+  // Check user preferences
+  if (status.status === 'none' && !user.reminder_if_none_enabled) {
+    return false;
+  }
+
+  if (status.status === 'some' && !user.reminder_if_incomplete_enabled) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Send reminder email using Resend
+ */
+async function sendReminderEmail(
+  resend: any,
+  email: string,
+  username: string,
+  subject: string,
+  message: string,
+  status: HabitCompletionStatus
+): Promise<void> {
+  const htmlContent = `
+<!DOCTYPE html>
+<html lang="en" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">
+  <title>${subject}</title>
+  <!--[if mso]>
+  <noscript><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml></noscript>
+  <![endif]-->
+  <style>
+    :root { color-scheme: light dark; supported-color-schemes: light dark; }
+    body { margin: 0; padding: 0; background-color: #000000; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #ffffff; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table { border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; }
+    .email-wrapper { width: 100%; background-color: #000000; }
+    .email-container { max-width: 600px; background-color: #000000; }
+    .header { text-align: center; padding: 40px 40px 20px; border-bottom: 2px solid #333333; }
+    .app-name { color: #22c55e; font-size: 32px; font-weight: 600; margin: 0; }
+    .content { text-align: center; padding: 32px 40px; }
+    .greeting { color: #22c55e !important; font-size: 24px; font-weight: 600; margin: 0 0 20px; }
+    .message { font-size: 20px; color: #ffffff !important; margin: 30px 0; font-weight: 500; line-height: 1.5; }
+    .stats-text { color: #cccccc !important; font-size: 15px; margin: 0; }
+    .cta-button { display: inline-block; background-color: #22c55e; color: #ffffff !important; text-decoration: none; padding: 16px 32px; border-radius: 8px; font-size: 16px; font-weight: 600; mso-padding-alt: 0; }
+    .footer { padding: 20px 40px 40px; border-top: 1px solid #333333; text-align: center; }
+    .footer-text { color: #cccccc !important; font-size: 14px; margin: 10px 0; }
+
+    /* ── Light mode overrides ── */
+    @media (prefers-color-scheme: light) {
+      body, .email-wrapper, .email-container { background-color: #f9fafb !important; }
+      .header { border-bottom-color: #e5e7eb !important; }
+      .message { color: #111827 !important; }
+      .stats-text { color: #374151 !important; }
+      .footer { border-top-color: #e5e7eb !important; }
+      .footer-text { color: #6b7280 !important; }
+    }
+
+    /* Outlook.com dark mode */
+    [data-ogsc] body, [data-ogsc] .email-wrapper, [data-ogsc] .email-container { background-color: #000000 !important; }
+    [data-ogsc] .message { color: #ffffff !important; }
+    [data-ogsc] .stats-text { color: #cccccc !important; }
+
+    /* ── Mobile ── */
+    @media only screen and (max-width: 600px) {
+      .email-container { width: 100% !important; }
+      .header, .content, .footer { padding-left: 24px !important; padding-right: 24px !important; }
+      .app-name { font-size: 28px !important; }
+      .message { font-size: 18px !important; }
+      .cta-button { padding: 14px 28px !important; font-size: 15px !important; }
+    }
+  </style>
+</head>
+<body>
+  <!-- Preheader -->
+  <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${status.completedToday} of ${status.totalHabits} habits tracked today — don't stop now! &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;</div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="email-wrapper">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" class="email-container">
+
+          <!-- Header -->
+          <tr>
+            <td class="header">
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 auto 16px;">
+                <tr>
+                  <td style="width:48px;height:48px;background-color:#22c55e;border-radius:12px;text-align:center;vertical-align:middle;">
+                    <span style="color:#ffffff;font-size:24px;font-weight:700;line-height:1;">H</span>
+                  </td>
+                </tr>
+              </table>
+              <h1 class="app-name">Grains of Sand</h1>
+            </td>
+          </tr>
+
+          <!-- Content -->
+          <tr>
+            <td class="content">
+              <h2 class="greeting">Hey ${username}! 👋</h2>
+
+              <p class="message">${message}</p>
+
+              <!-- Stats box -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 24px auto; width: 100%; max-width: 400px;">
+                <tr>
+                  <td style="background-color:#1a1a1a;border-left:4px solid #22c55e;border-radius:4px;padding:16px;text-align:left;">
+                    <p class="stats-text">
+                      <strong style="color:#22c55e;">Today's Progress:</strong>
+                      ${status.completedToday} of ${status.totalHabits} habits tracked
+                    </p>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- CTA -->
+              <!--[if mso]>
+              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word"
+                href="https://grainsofsand.app"
+                style="height:52px;v-text-anchor:middle;width:260px;"
+                arcsize="15%" fillcolor="#22c55e" strokecolor="#22c55e">
+                <w:anchorlock/>
+                <center style="color:#ffffff;font-family:sans-serif;font-size:16px;font-weight:600;">Track Your Habits Now →</center>
+              </v:roundrect>
+              <![endif]-->
+              <!--[if !mso]><!-->
+              <div style="padding: 10px 0 30px;">
+                <a href="https://grainsofsand.app" class="cta-button">Track Your Habits Now →</a>
+              </div>
+              <!--<![endif]-->
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td class="footer">
+              <p class="footer-text">You're receiving this because you enabled daily habit reminders in your notification settings.</p>
+              <p class="footer-text"><a href="https://grainsofsand.app/profile/edit" style="color:#22c55e;text-decoration:none;">Manage notification preferences</a></p>
+              <p style="color:#22c55e;font-weight:600;font-size:14px;margin:10px 0 0;">Keep building those habits! 🌱</p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+  `;
+
+  try {
+    await resend.emails.send({
+      from: 'Grains of Sand <noreply@grainsofsand.app>',
+      to: email,
+      subject: subject,
+      html: htmlContent,
+    });
+  } catch (error) {
+    console.error('Error sending email via Resend:', error);
+    throw error;
+  }
+}

--- a/supabase/functions/send-daily-reminders/index.ts
+++ b/supabase/functions/send-daily-reminders/index.ts
@@ -1,0 +1,461 @@
+// @ts-nocheck - Deno Edge Function (uses Deno runtime, not Node.js)
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.50.2';
+import { Resend } from 'https://esm.sh/resend@3.2.0';
+import { getEmailContent } from './messages.ts';
+
+// CORS headers for allowing requests
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+interface HabitCompletionStatus {
+  totalHabits: number;
+  completedToday: number;
+  status: 'all' | 'some' | 'none';
+}
+
+interface UserToNotify {
+  user_id: string;
+  email: string;
+  username: string;
+  reminder_if_incomplete_enabled: boolean;
+  reminder_if_none_enabled: boolean;
+  reminder_time: string;
+  timezone: string;
+}
+
+/**
+ * Main handler for daily habit reminder emails
+ */
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    console.log('Starting daily habit reminder job...');
+
+    // Initialize Supabase client with service role key (needed to access auth.users)
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const resendApiKey = Deno.env.get('RESEND_API_KEY')!;
+
+    if (!resendApiKey) {
+      throw new Error('RESEND_API_KEY environment variable is not set');
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const resend = new Resend(resendApiKey);
+
+    // Get today's date in YYYY-MM-DD format
+    const today = new Date().toLocaleDateString('en-CA');
+    console.log(`Processing reminders for date: ${today}`);
+
+    // Step 1: Get all users who have email notifications enabled
+    const { data: notificationPrefs, error: prefsError } = await supabase
+      .from('notification_preferences')
+      .select('user_id, reminder_if_incomplete_enabled, reminder_if_none_enabled, reminder_time, timezone')
+      .eq('email_enabled', true)
+      .eq('daily_reminder_enabled', true);
+
+    if (prefsError) {
+      console.error('Error fetching notification preferences:', prefsError);
+      throw prefsError;
+    }
+
+    if (!notificationPrefs || notificationPrefs.length === 0) {
+      console.log('No users with email notifications enabled');
+      return new Response(
+        JSON.stringify({ message: 'No users to notify' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
+      );
+    }
+
+    console.log(`Found ${notificationPrefs.length} users with notifications enabled`);
+
+    // Step 2: Get user emails and usernames from auth and profiles
+    const usersToNotify: UserToNotify[] = [];
+
+    for (const pref of notificationPrefs) {
+      try {
+        // Get user email from auth.users
+        const { data: authData, error: authError } = await supabase.auth.admin.getUserById(pref.user_id);
+
+        if (authError || !authData.user || !authData.user.email) {
+          console.log(`Skipping user ${pref.user_id} - no email found`);
+          continue;
+        }
+
+        // Get username from user_profiles
+        const { data: profileData, error: profileError } = await supabase
+          .from('user_profiles')
+          .select('username')
+          .eq('id', pref.user_id)
+          .single();
+
+        if (profileError || !profileData) {
+          console.log(`Skipping user ${pref.user_id} - no profile found`);
+          continue;
+        }
+
+        usersToNotify.push({
+          user_id: pref.user_id,
+          email: authData.user.email,
+          username: profileData.username,
+          reminder_if_incomplete_enabled: pref.reminder_if_incomplete_enabled,
+          reminder_if_none_enabled: pref.reminder_if_none_enabled,
+          reminder_time: pref.reminder_time,
+          timezone: pref.timezone,
+        });
+      } catch (err) {
+        console.error(`Error processing user ${pref.user_id}:`, err);
+      }
+    }
+
+    console.log(`Processing ${usersToNotify.length} users for habit completion status`);
+
+    // Get current UTC hour
+    const currentUtcHour = new Date().getUTCHours();
+
+    // Step 3: For each user, check if it's their reminder time, then check habits and send email
+    let emailsSent = 0;
+    let emailsSkipped = 0;
+
+    for (const user of usersToNotify) {
+      // Check if it's the right time for this user based on their timezone
+      if (!isReminderTime(user.timezone, user.reminder_time, currentUtcHour)) {
+        console.log(`Skipping user ${user.username} - not their reminder time yet`);
+        emailsSkipped++;
+        continue;
+      }
+      try {
+        // Get habit completion status
+        const status = await getHabitCompletionStatus(supabase, user.user_id, today);
+
+        console.log(`User ${user.username}: ${status.completedToday}/${status.totalHabits} habits completed`);
+
+        // Determine if we should send an email
+        const shouldSend = shouldSendEmail(user, status);
+
+        if (!shouldSend) {
+          console.log(`Skipping user ${user.username} - no email needed`);
+          emailsSkipped++;
+          continue;
+        }
+
+        // Determine email type
+        const emailType = status.status === 'none' ? 'none' : 'incomplete';
+
+        // Get email content with random funny message
+        const { subject, message } = getEmailContent(emailType);
+
+        // Send email via Resend
+        await sendReminderEmail(
+          resend,
+          user.email,
+          user.username,
+          subject,
+          message,
+          status
+        );
+
+        console.log(`Sent ${emailType} email to ${user.username} (${user.email})`);
+        emailsSent++;
+
+      } catch (err) {
+        console.error(`Error processing user ${user.username}:`, err);
+      }
+    }
+
+    console.log(`Job complete. Sent: ${emailsSent}, Skipped: ${emailsSkipped}`);
+
+    return new Response(
+      JSON.stringify({
+        message: 'Daily reminders processed',
+        emailsSent,
+        emailsSkipped,
+        totalUsers: usersToNotify.length,
+      }),
+      {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 200,
+      }
+    );
+
+  } catch (error) {
+    console.error('Error in daily reminder function:', error);
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 500,
+      }
+    );
+  }
+});
+
+/**
+ * Get habit completion status for a user on a specific date
+ */
+async function getHabitCompletionStatus(
+  supabase: any,
+  userId: string,
+  date: string
+): Promise<HabitCompletionStatus> {
+  // Get total active habits (not archived)
+  const { data: habits, error: habitsError } = await supabase
+    .from('habits')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('is_archived', false);
+
+  if (habitsError) {
+    console.error('Error fetching habits:', habitsError);
+    throw habitsError;
+  }
+
+  const totalHabits = habits?.length ?? 0;
+
+  // Get today's completions
+  const { data: completions, error: completionsError } = await supabase
+    .from('habit_completions')
+    .select('habit_id')
+    .eq('user_id', userId)
+    .eq('completion_date', date);
+
+  if (completionsError) {
+    console.error('Error fetching completions:', completionsError);
+    throw completionsError;
+  }
+
+  const completedToday = completions?.length ?? 0;
+
+  // Determine status
+  let status: 'all' | 'some' | 'none';
+  if (totalHabits === 0 || completedToday === 0) {
+    status = 'none';
+  } else if (completedToday === totalHabits) {
+    status = 'all';
+  } else {
+    status = 'some';
+  }
+
+  return {
+    totalHabits,
+    completedToday,
+    status,
+  };
+}
+
+/**
+ * Determine if we should send an email to this user based on their preferences and status
+ */
+function shouldSendEmail(user: UserToNotify, status: HabitCompletionStatus): boolean {
+  // Don't send if all habits completed
+  if (status.status === 'all') {
+    return false;
+  }
+
+  // Don't send if user has no habits
+  if (status.totalHabits === 0) {
+    return false;
+  }
+
+  // Check user preferences
+  if (status.status === 'none' && !user.reminder_if_none_enabled) {
+    return false;
+  }
+
+  if (status.status === 'some' && !user.reminder_if_incomplete_enabled) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check if current UTC hour matches user's reminder time in their timezone
+ */
+function isReminderTime(timezone: string, reminderTime: string, currentUtcHour: number): boolean {
+  try {
+    // Parse the reminder time (HH:MM:SS format)
+    const reminderHour = parseInt(reminderTime.split(':')[0]);
+
+    // Calculate timezone offset in hours
+    const now = new Date();
+
+    // Create a date in the user's timezone
+    const userTimeString = now.toLocaleString('en-US', {
+      timeZone: timezone,
+      hour: 'numeric',
+      hour12: false
+    });
+
+    const userHour = parseInt(userTimeString);
+
+    // Check if user's current hour matches their reminder hour
+    return userHour === reminderHour;
+  } catch (error) {
+    console.error(`Error checking reminder time for timezone ${timezone}:`, error);
+    // Default to sending if there's an error parsing timezone
+    return true;
+  }
+}
+
+/**
+ * Send reminder email using Resend
+ */
+async function sendReminderEmail(
+  resend: any,
+  email: string,
+  username: string,
+  subject: string,
+  message: string,
+  status: HabitCompletionStatus
+): Promise<void> {
+  const htmlContent = `
+<!DOCTYPE html>
+<html lang="en" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">
+  <title>${subject}</title>
+  <!--[if mso]>
+  <noscript><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml></noscript>
+  <![endif]-->
+  <style>
+    :root { color-scheme: light dark; supported-color-schemes: light dark; }
+    body { margin: 0; padding: 0; background-color: #000000; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #ffffff; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table { border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; }
+    .email-wrapper { width: 100%; background-color: #000000; }
+    .email-container { max-width: 600px; background-color: #000000; }
+    .header { text-align: center; padding: 40px 40px 20px; border-bottom: 2px solid #333333; }
+    .app-name { color: #22c55e; font-size: 32px; font-weight: 600; margin: 0; }
+    .content { text-align: center; padding: 32px 40px; }
+    .greeting { color: #22c55e !important; font-size: 24px; font-weight: 600; margin: 0 0 20px; }
+    .message { font-size: 20px; color: #ffffff !important; margin: 30px 0; font-weight: 500; line-height: 1.5; }
+    .stats-text { color: #cccccc !important; font-size: 15px; margin: 0; }
+    .cta-button { display: inline-block; background-color: #22c55e; color: #ffffff !important; text-decoration: none; padding: 16px 32px; border-radius: 8px; font-size: 16px; font-weight: 600; mso-padding-alt: 0; }
+    .footer { padding: 20px 40px 40px; border-top: 1px solid #333333; text-align: center; }
+    .footer-text { color: #cccccc !important; font-size: 14px; margin: 10px 0; }
+
+    /* ── Light mode overrides ── */
+    @media (prefers-color-scheme: light) {
+      body, .email-wrapper, .email-container { background-color: #f9fafb !important; }
+      .header { border-bottom-color: #e5e7eb !important; }
+      .message { color: #111827 !important; }
+      .stats-text { color: #374151 !important; }
+      .footer { border-top-color: #e5e7eb !important; }
+      .footer-text { color: #6b7280 !important; }
+    }
+
+    /* Outlook.com dark mode */
+    [data-ogsc] body, [data-ogsc] .email-wrapper, [data-ogsc] .email-container { background-color: #000000 !important; }
+    [data-ogsc] .message { color: #ffffff !important; }
+    [data-ogsc] .stats-text { color: #cccccc !important; }
+
+    /* ── Mobile ── */
+    @media only screen and (max-width: 600px) {
+      .email-container { width: 100% !important; }
+      .header, .content, .footer { padding-left: 24px !important; padding-right: 24px !important; }
+      .app-name { font-size: 28px !important; }
+      .message { font-size: 18px !important; }
+      .cta-button { padding: 14px 28px !important; font-size: 15px !important; }
+    }
+  </style>
+</head>
+<body>
+  <!-- Preheader -->
+  <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${status.completedToday} of ${status.totalHabits} habits tracked today — don't stop now! &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;</div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="email-wrapper">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" class="email-container">
+
+          <!-- Header -->
+          <tr>
+            <td class="header">
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 auto 16px;">
+                <tr>
+                  <td style="width:48px;height:48px;background-color:#22c55e;border-radius:12px;text-align:center;vertical-align:middle;">
+                    <span style="color:#ffffff;font-size:24px;font-weight:700;line-height:1;">H</span>
+                  </td>
+                </tr>
+              </table>
+              <h1 class="app-name">Grains of Sand</h1>
+            </td>
+          </tr>
+
+          <!-- Content -->
+          <tr>
+            <td class="content">
+              <h2 class="greeting">Hey ${username}! 👋</h2>
+
+              <p class="message">${message}</p>
+
+              <!-- Stats box -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 24px auto; width: 100%; max-width: 400px;">
+                <tr>
+                  <td style="background-color:#1a1a1a;border-left:4px solid #22c55e;border-radius:4px;padding:16px;text-align:left;">
+                    <p class="stats-text">
+                      <strong style="color:#22c55e;">Today's Progress:</strong>
+                      ${status.completedToday} of ${status.totalHabits} habits tracked
+                    </p>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- CTA -->
+              <!--[if mso]>
+              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word"
+                href="https://grainsofsand.app"
+                style="height:52px;v-text-anchor:middle;width:260px;"
+                arcsize="15%" fillcolor="#22c55e" strokecolor="#22c55e">
+                <w:anchorlock/>
+                <center style="color:#ffffff;font-family:sans-serif;font-size:16px;font-weight:600;">Track Your Habits Now →</center>
+              </v:roundrect>
+              <![endif]-->
+              <!--[if !mso]><!-->
+              <div style="padding: 10px 0 30px;">
+                <a href="https://grainsofsand.app" class="cta-button">Track Your Habits Now →</a>
+              </div>
+              <!--<![endif]-->
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td class="footer">
+              <p class="footer-text">You're receiving this because you enabled daily habit reminders in your notification settings.</p>
+              <p class="footer-text"><a href="https://grainsofsand.app/profile/edit" style="color:#22c55e;text-decoration:none;">Manage notification preferences</a></p>
+              <p style="color:#22c55e;font-weight:600;font-size:14px;margin:10px 0 0;">Keep building those habits! 🌱</p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+  `;
+
+  try {
+    await resend.emails.send({
+      from: 'Grains of Sand <noreply@grainsofsand.app>',
+      to: email,
+      subject: subject,
+      html: htmlContent,
+    });
+  } catch (error) {
+    console.error('Error sending email via Resend:', error);
+    throw error;
+  }
+}

--- a/supabase/functions/send-daily-reminders/messages.ts
+++ b/supabase/functions/send-daily-reminders/messages.ts
@@ -1,0 +1,75 @@
+/**
+ * Funny message templates for daily habit reminder emails
+ * Inspired by Duolingo's playful, guilt-inducing style
+ */
+
+export const INCOMPLETE_MESSAGES = [
+  "Please I'm begging, complete a habit",
+  "I'm yearning for you to track some habits",
+  "Hey queen, I miss you 👑",
+  "Your habits are feeling lonely...",
+  "Don't leave me hanging! Track those habits 🌟",
+  "I'm not mad, just disappointed 😔",
+  "Your future self called, they want those habits tracked",
+  "Come back... the habits need you",
+  "Just checking in... your habits are getting cold",
+  "I'll be here. Waiting. Patiently. Forever... 🥺",
+];
+
+export const INCOMPLETE_SUBJECTS = [
+  "Your habits are giving me abandonment issues 🥺",
+  "We need to talk about your habits...",
+  "Your habits: 📉 My disappointment: 📈",
+  "I see you started... but didn't finish 👀",
+  "So close, yet so far... (from completing your habits)",
+  "Your habits miss you already",
+];
+
+export const NO_TRACKING_MESSAGES = [
+  "Seriously? Not even ONE habit today? 😱",
+  "I'm not crying, you're crying (because no habits tracked)",
+  "This is your sign to track a habit. This is it. Right now.",
+  "Your habits miss you more than I do",
+  "Zero habits tracked. My disappointment is immeasurable.",
+  "I see how it is... leaving me on read AND your habits untracked",
+  "The habits are sad. I'm sad. Everyone's sad. Except you, apparently.",
+  "NOT A SINGLE HABIT? Bold strategy.",
+  "Your habits called. They want to know if you're okay.",
+  "Breaking news: Local person forgets they have habits to track",
+];
+
+export const NO_TRACKING_SUBJECTS = [
+  "This is fine. Everything is fine. (It's not fine) 🔥",
+  "We need to talk about today... 😬",
+  "Your habits: 0. My concern: 📈",
+  "Houston, we have a problem...",
+  "NOT EVEN ONE?! 😱",
+  "Your habits are filing a missing person report",
+];
+
+/**
+ * Get a random message from an array
+ */
+export function getRandomMessage(messages: string[]): string {
+  return messages[Math.floor(Math.random() * messages.length)];
+}
+
+/**
+ * Get subject line and message for email based on completion type
+ */
+export function getEmailContent(type: 'incomplete' | 'none'): {
+  subject: string;
+  message: string;
+} {
+  if (type === 'incomplete') {
+    return {
+      subject: getRandomMessage(INCOMPLETE_SUBJECTS),
+      message: getRandomMessage(INCOMPLETE_MESSAGES),
+    };
+  } else {
+    return {
+      subject: getRandomMessage(NO_TRACKING_SUBJECTS),
+      message: getRandomMessage(NO_TRACKING_MESSAGES),
+    };
+  }
+}


### PR DESCRIPTION
Closes #543

## Summary
- Rewrites the inline reminder email HTML to properly handle dark and light mode across email clients
- Fixes the gray-on-dark message text and inverted stats box seen in the previous version
- Adds targeted testing so the test function can send to a single email instead of all users

## Changes

**Both edge functions (`send-daily-reminders` and `send-daily-reminders-test`):**
- Table-based layout replacing div-based (better email client compatibility)
- `color-scheme` meta tags + `@media (prefers-color-scheme: light)` overrides for light mode users
- `[data-ogsc]` selectors for Outlook.com dark mode
- VML `<v:roundrect>` CTA button for Outlook desktop
- H icon centered via table cell (consistent across clients)
- Preheader preview text
- Sender name changed from "Habit Tracker" to "Grains of Sand"

**Test function only:**
- Accepts optional `test_email` in the POST body — when provided, only sends to that address
- Usage: pass `{ "test_email": "you@example.com" }` in the Supabase dashboard test panel

## Test plan
- [ ] Invoke `send-daily-reminders-test` with `{ "test_email": "your@email.com" }` — confirm only one email received
- [ ] Check email renders correctly in dark mode (message text visible, stats box dark)
- [ ] Check email renders correctly in light mode (background light, text dark)
- [ ] Confirm sender shows as "Grains of Sand" not "Habit Tracker"
- [ ] Confirm H icon is centered in the header